### PR TITLE
fix the str_replace error for php8.1

### DIFF
--- a/src/helper/Util.php
+++ b/src/helper/Util.php
@@ -275,7 +275,7 @@ class Util
     {
         $content    =   ShortcodeParser::get_active()->parse($content);
 
-        if (!Director::isLive()) {
+        if (!Director::isLive() && $content) {
             $content   =   str_replace('<img src="', '<img src="' . rtrim(Director::absoluteBaseURL(), '/'), $content);
         }
 


### PR DESCRIPTION
The value of $content may have a Null value which will cause an error in PHP 8.1

[Deprecated] str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated